### PR TITLE
IBM437 has alias cp437

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,7 +693,7 @@ pub fn decode_string(bytes: &Vec<u8>, label: &str) -> KResult<String> {
     }
 
     let enc = label.to_lowercase();
-    if enc == "cp437" {
+    if enc == "cp437" || enc == "ibm437" {
         use std::io::BufReader;
         let reader = BufReader::new(bytes.as_slice());
         let mut buffer = reader.bytes();


### PR DESCRIPTION
[Code page 437](https://en.wikipedia.org/wiki/Code_page_437) says that `MIME / IANA | IBM437` has `CP437, OEM-US, OEM 437, PC-8, or DOS Latin US` aliases. 
This fixed the `test_expr_str_encodings.rs`.
